### PR TITLE
fix: only run labels action when issue or PR is opened

### DIFF
--- a/.github/workflows/add_reponame_labels.yml
+++ b/.github/workflows/add_reponame_labels.yml
@@ -2,7 +2,11 @@ name: Auto add reponame as label to all issues and PRs
 
 on:
   issues:
+    types:
+      - opened
   pull_request:
+    types:
+      - opened
 
 jobs:
   add_label:


### PR DESCRIPTION
Otherwise, it runs every time new commits are pushed to a branch with an open PR.

This version of the workflow has this correction: https://github.com/CCBR/.github/blob/58cae128e4dc13c05186a2f187c6114653ebc843/.github/workflows/reponame_labels.yaml