### PR TITLE
fix(projark): send required metadata when registering HPC-DME collections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build/
+**/tmp/*
 **/site/*
 **/dist/*
 **/*.egg_info/*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## parkit development version
 
+- Fixed `projark deposit` HTTP 400 errors from HPC-DME when creating Project and Analysis/Rawdata collections (#53, @kopardev):
+  - `_register_collection` now accepts `extra_metadata` to send all required DME fields.
+  - Project collections are registered with: `project_title`, `project_description`, `origin`, `method`, `access`, `organism`, `summary_of_samples`, `project_start_date`.
+  - Analysis/Rawdata sub-collections are registered with: `project_start_date`, `method`, `number_of_cases`.
+  - `Rawdata` datatype is mapped to DME `collection_type` value `Analysis` (valid values: `Project`, `PI_Lab`, `Sample`, `Analysis`).
+
 ## v3.0.1
 
 - Added short options for `projark` subcommands (#45, @kopardev):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## parkit development version
 
+- Fixed HPC-DME CLI `*.tmp` response files (e.g. `collection-registration-response-message.json.tmp`, `get-item-response-header.tmp`) accumulating in the user's working directory after every `projark` run. `run_dm_cmd` now executes each `dm_*` subprocess inside a per-call `tempfile.TemporaryDirectory` named `parkit_<username>_<random>/`, so all temp files are isolated and automatically deleted on return. This also prevents concurrent runs by the same or different users from overwriting each other's temp files. (#60, @kopardev)
 - Fixed `projark deposit` HTTP 400 errors from HPC-DME when creating Project and Analysis/Rawdata collections (#53, @kopardev):
   - `_register_collection` now accepts `extra_metadata` to send all required DME fields.
   - Project collections are registered with: `project_title`, `project_description`, `origin`, `method`, `access`, `organism`, `summary_of_samples`, `project_start_date`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - After Step 2 in `projark deposit`, print the active (non-comment) lines from `$HPC_DM_UTILS/hpcdme.properties` with a 4-space indent so users can verify their HPC-DME configuration before the transfer begins. (#56, @kopardev)
 - After Step 2 in `projark deposit`, check that proxy settings (`hpc.server.proxy.url`, `hpc.server.proxy.port`) are commented out in `hpcdme.properties`; abort with a descriptive error if any are active. Per HPC-DME team guidance (Udit Sehgal), proxy lines must not be set. (#57, @kopardev)
 - Exclude dot files (filenames starting with `.`) from `dm_register_directory` during deposit by passing a temp exclude file with patterns `.*` and `**/.*` via the `-e` flag. Prevents hidden files such as shell per-directory history files from being registered to HPC-DME. (#58, @kopardev)
+- Before `dm_register_directory`, check whether any staged file already exists in the destination HPC-DME collection; if so, rename all staged files (primary and `.md5`) by inserting a zero-padded counter before the first extension (e.g. `ccbr1431.tar` → `ccbr1431_001.tar`), using the lowest available counter so previous deposits are never overwritten. (#59, @kopardev)
 
 ## v3.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
   - `Rawdata` datatype is mapped to DME `collection_type` value `Analysis` (valid values: `Project`, `PI_Lab`, `Sample`, `Analysis`).
 - After Step 2 in `projark deposit`, print the active (non-comment) lines from `$HPC_DM_UTILS/hpcdme.properties` with a 4-space indent so users can verify their HPC-DME configuration before the transfer begins. (#56, @kopardev)
 - After Step 2 in `projark deposit`, check that proxy settings (`hpc.server.proxy.url`, `hpc.server.proxy.port`) are commented out in `hpcdme.properties`; abort with a descriptive error if any are active. Per HPC-DME team guidance (Udit Sehgal), proxy lines must not be set. (#57, @kopardev)
+- Exclude dot files (filenames starting with `.`) from `dm_register_directory` during deposit by passing a temp exclude file with patterns `.*` and `**/.*` via the `-e` flag. Prevents hidden files such as shell per-directory history files from being registered to HPC-DME. (#58, @kopardev)
 
 ## v3.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
   - Project collections are registered with: `project_title`, `project_description`, `origin`, `method`, `access`, `organism`, `summary_of_samples`, `project_start_date`.
   - Analysis/Rawdata sub-collections are registered with: `project_start_date`, `method`, `number_of_cases`.
   - `Rawdata` datatype is mapped to DME `collection_type` value `Analysis` (valid values: `Project`, `PI_Lab`, `Sample`, `Analysis`).
+- After Step 2 in `projark deposit`, print the active (non-comment) lines from `$HPC_DM_UTILS/hpcdme.properties` with a 4-space indent so users can verify their HPC-DME configuration before the transfer begins. (#56, @kopardev)
+- After Step 2 in `projark deposit`, check that proxy settings (`hpc.server.proxy.url`, `hpc.server.proxy.port`) are commented out in `hpcdme.properties`; abort with a descriptive error if any are active. Per HPC-DME team guidance (Udit Sehgal), proxy lines must not be set. (#57, @kopardev)
 
 ## v3.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 ## parkit development version
 
+- Added `projark ls <projectnumber>` subcommand to list all data objects in a project's HPC-DME vault collection as a tree with human-readable sizes, depositor name, and deposit date (#62, @kopardev):
+  - Uses a single `dm_query_dataobject` call (no extra API calls for per-file metadata).
+  - Groups objects by sub-collection (`Analysis/`, `Rawdata/`) with sub-collection size totals.
+  - Each file row shows: filename, size, depositor (`registered_by_name`), deposit date (`data_transfer_completed`, formatted as `YYMMDD`).
+  - Accepts the same project number formats as `deposit`/`retrieve` (e.g. `projark ls 982`, `projark ls ccbr982`, `projark ls CCBR-982`).
+  - No Helix, tmux, or sync-gate checks required (read-only operation).
+  - Prints a note that newly deposited files may not appear for up to 60 minutes (DME search index lag).
+  - Does not send a completion email.
+- Fixed `projark deposit` name-conflict detection to also check for the first split-chunk suffix (`*.tar_0001`) when testing whether a base tar name is already taken in HPC-DME. Previously, a project whose tarball was split on a prior deposit (producing `ccbr982.tar_0001`, `ccbr982.tar_0002`, …) would not be detected as a conflict because the base name `ccbr982.tar` never exists as a data object. (#61, @kopardev)
+- Improved `projark retrieve` (#62, @kopardev):
+  - Replaced N serial `dm_get_dataobject` existence checks (one per `--filenames` entry) with a single `dm_query_dataobject` call; all requested filenames are validated against the returned in-memory name set.
+  - After fetching the object listing, automatically detects split tar parts (`*.tar_NNNN`) in the collection and prints an advisory message if `--unsplit` was not passed.
 - Fixed HPC-DME CLI `*.tmp` response files (e.g. `collection-registration-response-message.json.tmp`, `get-item-response-header.tmp`) accumulating in the user's working directory after every `projark` run. `run_dm_cmd` now executes each `dm_*` subprocess inside a per-call `tempfile.TemporaryDirectory` named `parkit_<username>_<random>/`, so all temp files are isolated and automatically deleted on return. This also prevents concurrent runs by the same or different users from overwriting each other's temp files. (#60, @kopardev)
 - Fixed `projark deposit` HTTP 400 errors from HPC-DME when creating Project and Analysis/Rawdata collections (#53, @kopardev):
   - `_register_collection` now accepts `extra_metadata` to send all required DME fields.

--- a/src/parkit/__main__.py
+++ b/src/parkit/__main__.py
@@ -195,11 +195,11 @@ def main():
     elif args.command == "syncapi":
         syncapi(args.repo)
     elif args.command == "ls":
-        print(
-            "Note: DME search index may lag up to 60 minutes behind recent deposits."
-        )
+        print("Note: DME search index may lag up to 60 minutes behind recent deposits.")
         if not collection_exists(args.collection_path):
-            print(f"ERROR: Collection does not exist in HPC-DME: {args.collection_path}")
+            print(
+                f"ERROR: Collection does not exist in HPC-DME: {args.collection_path}"
+            )
             sys.exit(1)
         sys.exit(ls_collection(args.collection_path, json_output=args.json))
     for f in files_created:

--- a/src/parkit/__main__.py
+++ b/src/parkit/__main__.py
@@ -1,12 +1,15 @@
 #!/usr/bin/env python3
 
 import argparse
+import sys
 from parkit.src.createtar import createtar, tarprep
 from parkit.src.createmetadata import createmetadata
 from parkit.src.createemptycollection import createemptycollection
 from parkit.src.deposittar import deposittocollection
 from parkit.src.checkapisync import check_hpc_dme_apis_sync
 from parkit.src.syncapi import syncapi
+from parkit.src.lscollection import ls_collection
+from parkit.src.utils import collection_exists
 from parkit.src.VersionCheck import __version__
 
 
@@ -120,6 +123,24 @@ def main():
         default="Analysis",  # or Rawdata
     )
 
+    # Create a subcommand for "ls"
+    parser_ls = subparsers.add_parser(
+        "ls",
+        help="list data objects under any HPC-DME collection path",
+    )
+    parser_ls.add_argument(
+        "collection_path",
+        metavar="COLLECTION_PATH",
+        type=str,
+        help="Full HPC-DME collection path (e.g. /CCBR_Archive/GRIDFTP/Project_CCBR-982)",
+    )
+    parser_ls.add_argument(
+        "--json",
+        action="store_true",
+        default=False,
+        help="Emit results as a JSON array instead of the tree view",
+    )
+
     # Support "parkit <subcommand> --version" for all subcommands.
     subcommand_parsers = [
         parser_createtar,
@@ -129,6 +150,7 @@ def main():
         parser_createmetadata,
         parser_createemptycollection,
         parser_deposittar,
+        parser_ls,
     ]
     for subparser in subcommand_parsers:
         subparser.add_argument("-v", "--version", action="version", version=__version__)
@@ -145,6 +167,7 @@ def main():
         "deposittar",
         "checkapisync",
         "syncapi",
+        "ls",
     ]
     if args.command not in subcommands:
         parser.print_help()
@@ -171,6 +194,14 @@ def main():
         check_hpc_dme_apis_sync(args.repo)
     elif args.command == "syncapi":
         syncapi(args.repo)
+    elif args.command == "ls":
+        print(
+            "Note: DME search index may lag up to 60 minutes behind recent deposits."
+        )
+        if not collection_exists(args.collection_path):
+            print(f"ERROR: Collection does not exist in HPC-DME: {args.collection_path}")
+            sys.exit(1)
+        sys.exit(ls_collection(args.collection_path, json_output=args.json))
     for f in files_created:
         print(f"createmetadata: {f} file was created!")
 

--- a/src/parkit/projark.py
+++ b/src/parkit/projark.py
@@ -701,6 +701,154 @@ def _run_retrieve(args):
     return 0
 
 
+_LS_CRITERIA = {
+    "compoundQuery": {
+        "operator": "AND",
+        "queries": [
+            {
+                "attribute": "source_file_size",
+                "value": "0",
+                "operator": "NUM_GREATER_OR_EQUAL",
+            }
+        ],
+    },
+    "detailedResponse": True,
+    "page": 1,
+    "totalCount": True,
+}
+
+
+def _query_all_dataobjects(project_path):
+    """Return a list of (absolute_path, size_bytes) for every data object under
+    *project_path*, iterating through all pages."""
+    objects = []
+    page = 1
+    while True:
+        criteria = dict(_LS_CRITERIA)
+        criteria["page"] = page
+        with NamedTemporaryFile("w", suffix=".json", delete=False) as tmp:
+            json.dump(criteria, tmp, indent=2)
+            criteria_file = tmp.name
+        try:
+            cmd = (
+                f"dm_query_dataobject -o /dev/stdout"
+                f" {shlex.quote(criteria_file)} {shlex.quote(project_path)}"
+            )
+            proc = run_dm_cmd(
+                dm_cmd=cmd,
+                errormsg="dm_query_dataobject failed during ls",
+                returnproc=True,
+                exitiffails=False,
+            )
+        finally:
+            if os.path.exists(criteria_file):
+                os.remove(criteria_file)
+
+        if proc.returncode != 0:
+            _info("dm_query_dataobject returned non-zero; no objects found or query failed.")
+            break
+
+        try:
+            data = json.loads(proc.stdout)
+        except (json.JSONDecodeError, AttributeError):
+            _info("Could not parse dm_query_dataobject output as JSON.")
+            break
+
+        page_items = data.get("dataObjects", []) or []
+        for item in page_items:
+            abs_path = (item.get("dataObject") or {}).get("absolutePath", "")
+            size = None
+            for entry in (item.get("metadataEntries") or {}).get("selfMetadataEntries", []):
+                if entry.get("attribute") == "source_file_size":
+                    try:
+                        size = int(entry["value"])
+                    except (ValueError, TypeError):
+                        pass
+                    break
+            if abs_path:
+                objects.append((abs_path, size))
+
+        total = data.get("totalCount", 0) or 0
+        limit = data.get("limit", 100) or 100
+        if page * limit >= total:
+            break
+        page += 1
+
+    return objects
+
+
+def _render_ls_tree(project_path, objects):
+    """Print a tree of *objects* grouped by their immediate parent sub-collection."""
+    # Group objects by their direct parent path (sub-collection)
+    sub_collections: dict[str, list[tuple[str, int | None]]] = {}
+    for abs_path, size in objects:
+        parent = str(Path(abs_path).parent)
+        sub_collections.setdefault(parent, []).append((abs_path, size))
+
+    # Compute sub-collection sizes (sum of known object sizes)
+    def _sub_size(items):
+        total = 0
+        for _, s in items:
+            if s is None:
+                return None
+            total += s
+        return total
+
+    # Project header — use the short name (last path component)
+    project_name = Path(project_path).name
+    total_all = sum(s for _, s in objects if s is not None) if objects else 0
+    print(f"{project_name}  ({_human_size(total_all)})")
+
+    sorted_subs = sorted(sub_collections.keys())
+    for sub_idx, sub_path in enumerate(sorted_subs):
+        is_last_sub = sub_idx == len(sorted_subs) - 1
+        sub_connector = "└──" if is_last_sub else "├──"
+        sub_name = Path(sub_path).name
+        sub_sz = _sub_size(sub_collections[sub_path])
+        sub_sz_str = f"  ({_human_size(sub_sz)})" if sub_sz is not None else ""
+        print(f"{sub_connector} {sub_name}/{sub_sz_str}")
+
+        child_prefix = "    " if is_last_sub else "│   "
+        items = sorted(sub_collections[sub_path], key=lambda x: Path(x[0]).name)
+        for item_idx, (abs_path, size) in enumerate(items):
+            is_last_item = item_idx == len(items) - 1
+            item_connector = "└──" if is_last_item else "├──"
+            fname = Path(abs_path).name
+            sz_str = _human_size(size) if size is not None else "unknown"
+            print(f"{child_prefix}{item_connector} {fname:<50}  {sz_str}")
+
+
+def _run_ls(args):
+    _print_hpcdme_properties()
+
+    project_number = args.projectnumber
+    project_path = _project_collection_path(project_number)
+    _info(f"Listing HPC-DME collection: {project_path}")
+    _info(
+        "Note: the DME search index may lag up to 60 minutes behind recent deposits."
+    )
+
+    _step(1, f"verifying project collection exists: {project_path}")
+    if not _collection_exists(project_path):
+        return _error(
+            f"Project collection does not exist in HPC-DME: {project_path}"
+        )
+    _ok("Project collection found.")
+
+    _step(2, "querying data objects ...")
+    objects = _query_all_dataobjects(project_path)
+    _ok(f"{len(objects)} object(s) found.")
+
+    if not objects:
+        _info("No data objects found under this project collection.")
+        return 0
+
+    print()
+    _render_ls_tree(project_path, objects)
+    print()
+    return 0
+
+
 def _build_parser():
     parser = argparse.ArgumentParser(
         description="projark: project archival helper built on parkit"
@@ -814,6 +962,23 @@ def _build_parser():
         help="Merge split parts (*.tar_0001, *.tar_0002, ...) into a tar after download",
     )
 
+    parser_ls = subparsers.add_parser(
+        "ls",
+        help="List data objects in /CCBR_Archive/GRIDFTP/Project_CCBR-<projectnumber>",
+    )
+    parser_ls.add_argument(
+        "-v",
+        "--version",
+        action="version",
+        version=f"projark is part of parkit; parkit version: {__version__}",
+    )
+    parser_ls.add_argument(
+        "projectnumber",
+        metavar="PROJECTNUMBER",
+        type=_normalize_project_number,
+        help="Project number (e.g. 982, ccbr982, CCBR-982)",
+    )
+
     return parser
 
 
@@ -829,6 +994,8 @@ def main():
             return_code = _run_deposit(args)
         elif args.command == "retrieve":
             return_code = _run_retrieve(args)
+        elif args.command == "ls":
+            return_code = _run_ls(args)
         else:
             parser.print_help()
             return_code = 1

--- a/src/parkit/projark.py
+++ b/src/parkit/projark.py
@@ -315,9 +315,15 @@ def _ensure_deposit_collections(base_collection, datatype, project_number):
             {"attribute": "access", "value": "Open Access"},
             {"attribute": "organism", "value": "unknown"},
             {"attribute": "summary_of_samples", "value": "unknown"},
-            {"attribute": "project_start_date", "value": today, "dateFormat": "yyyyMMdd"},
+            {
+                "attribute": "project_start_date",
+                "value": today,
+                "dateFormat": "yyyyMMdd",
+            },
         ]
-        _register_collection(base_collection, "Project", extra_metadata=project_metadata)
+        _register_collection(
+            base_collection, "Project", extra_metadata=project_metadata
+        )
     else:
         _info("Project collection exists.")
 
@@ -331,7 +337,9 @@ def _ensure_deposit_collections(base_collection, datatype, project_number):
         {"attribute": "method", "value": "NGS"},
         {"attribute": "number_of_cases", "value": "unknown"},
     ]
-    _register_collection(datatype_collection, datatype_collection_type, extra_metadata=datatype_metadata)
+    _register_collection(
+        datatype_collection, datatype_collection_type, extra_metadata=datatype_metadata
+    )
     return datatype_collection
 
 
@@ -419,7 +427,9 @@ def _run_deposit(args):
     project_tag = _project_tag(args.projectnumber)
     base_collection = _project_collection_path(args.projectnumber)
     datatype = args.datatype
-    datatype_collection = _ensure_deposit_collections(base_collection, datatype, args.projectnumber)
+    datatype_collection = _ensure_deposit_collections(
+        base_collection, datatype, args.projectnumber
+    )
 
     scratch_root, datatype_dir = _prepare_scratch_dirs(project_tag, datatype)
 

--- a/src/parkit/projark.py
+++ b/src/parkit/projark.py
@@ -75,6 +75,37 @@ def _print_hpcdme_properties():
         _info(f"Could not read {props_path}: {e}")
 
 
+_PROXY_KEYS = ("hpc.server.proxy.url", "hpc.server.proxy.port")
+
+
+def _check_no_proxy_settings():
+    """Return True if safe to proceed, False if active proxy lines are found."""
+    hpc_dm_utils = os.environ.get("HPC_DM_UTILS", "")
+    props_path = Path(hpc_dm_utils) / "hpcdme.properties"
+    bad_lines = []
+    try:
+        with open(props_path) as fh:
+            for lineno, line in enumerate(fh, start=1):
+                stripped = line.strip()
+                if stripped.startswith("#") or stripped == "":
+                    continue
+                if any(stripped.startswith(key) for key in _PROXY_KEYS):
+                    bad_lines.append((lineno, stripped))
+    except OSError as e:
+        _info(f"Could not read {props_path} for proxy check: {e}")
+        return True  # non-fatal; let the transfer attempt proceed
+    if bad_lines:
+        _error(
+            f"Active proxy settings found in {props_path}. "
+            "Per HPC-DME team guidance (Udit Sehgal), proxy lines must be "
+            "commented out. Please prefix each with '#' and retry."
+        )
+        for lineno, text in bad_lines:
+            print(f"    line {lineno}: {text}")
+        return False
+    return True
+
+
 def _resolved_path_for_report(raw_path):
     if not raw_path:
         return ""
@@ -438,6 +469,8 @@ def _run_deposit(args):
     _require_terminal_multiplexer()
     _ok("Session check passed (inside tmux/screen/Open OnDemand graphical session).")
     _print_hpcdme_properties()
+    if not _check_no_proxy_settings():
+        return 1
 
     source_folder = _resolve_existing_directory(args.folder)
     project_tag = _project_tag(args.projectnumber)

--- a/src/parkit/projark.py
+++ b/src/parkit/projark.py
@@ -499,8 +499,20 @@ def _run_deposit(args):
     _step(6, "transferring staged directory to HPC-DME ...")
     src_dir = f"{datatype_dir}/"
     dst_dir = f"{datatype_collection}/"
-    cmd = f"dm_register_directory -c -r -t 4 -s {shlex.quote(src_dir)} {shlex.quote(dst_dir)}"
-    run_dm_cmd(dm_cmd=cmd, errormsg="dm_register_directory failed during deposit.")
+    exclude_file = None
+    try:
+        with NamedTemporaryFile("w", suffix=".exclude", delete=False) as ef:
+            ef.write(".*\n**/.*\n")
+            exclude_file = ef.name
+        cmd = (
+            f"dm_register_directory -c -r -t 4 -s"
+            f" -e {shlex.quote(exclude_file)}"
+            f" {shlex.quote(src_dir)} {shlex.quote(dst_dir)}"
+        )
+        run_dm_cmd(dm_cmd=cmd, errormsg="dm_register_directory failed during deposit.")
+    finally:
+        if exclude_file and os.path.exists(exclude_file):
+            os.remove(exclude_file)
     _ok("Transfer completed.")
 
     if args.cleanup:

--- a/src/parkit/projark.py
+++ b/src/parkit/projark.py
@@ -705,7 +705,6 @@ def _run_retrieve(args):
     return 0
 
 
-
 def _run_ls(args):
     _print_hpcdme_properties()
 

--- a/src/parkit/projark.py
+++ b/src/parkit/projark.py
@@ -680,7 +680,9 @@ def _run_retrieve(args):
         _step(7, "verifying all requested objects exist ...")
         missing = [f for f in filenames if f not in known_names]
         for filename in filenames:
-            _info(f"  - {filename}: {'FOUND' if filename in known_names else 'MISSING'}")
+            _info(
+                f"  - {filename}: {'FOUND' if filename in known_names else 'MISSING'}"
+            )
         if missing:
             return _error(f"Cannot proceed; missing object(s): {', '.join(missing)}")
 
@@ -776,7 +778,9 @@ def _query_all_dataobjects(project_path):
                 os.remove(criteria_file)
 
         if proc.returncode != 0:
-            _info("dm_query_dataobject returned non-zero; no objects found or query failed.")
+            _info(
+                "dm_query_dataobject returned non-zero; no objects found or query failed."
+            )
             break
 
         try:
@@ -792,7 +796,9 @@ def _query_all_dataobjects(project_path):
             depositor_name = None
             depositor_id = None
             deposit_date = None
-            for entry in (item.get("metadataEntries") or {}).get("selfMetadataEntries", []):
+            for entry in (item.get("metadataEntries") or {}).get(
+                "selfMetadataEntries", []
+            ):
                 attr = entry.get("attribute")
                 if attr == "source_file_size":
                     try:
@@ -821,10 +827,14 @@ def _query_all_dataobjects(project_path):
 def _render_ls_tree(project_path, objects):
     """Print a tree of *objects* grouped by their immediate parent sub-collection."""
     # Group objects by their direct parent path (sub-collection)
-    sub_collections: dict[str, list[tuple[str, int | None, str | None, str | None]]] = {}
+    sub_collections: dict[
+        str, list[tuple[str, int | None, str | None, str | None]]
+    ] = {}
     for abs_path, size, depositor, deposit_date in objects:
         parent = str(Path(abs_path).parent)
-        sub_collections.setdefault(parent, []).append((abs_path, size, depositor, deposit_date))
+        sub_collections.setdefault(parent, []).append(
+            (abs_path, size, depositor, deposit_date)
+        )
 
     # Compute sub-collection sizes (sum of known object sizes)
     def _sub_size(items):
@@ -857,7 +867,9 @@ def _render_ls_tree(project_path, objects):
             fname = Path(abs_path).name
             sz_str = _human_size(size) if size is not None else "unknown"
             dep_col = ",".join(filter(None, [depositor, deposit_date])) or ""
-            print(f"{child_prefix}{item_connector} {fname:<50}  {sz_str:<12}  {dep_col}")
+            print(
+                f"{child_prefix}{item_connector} {fname:<50}  {sz_str:<12}  {dep_col}"
+            )
 
 
 def _run_ls(args):
@@ -866,15 +878,11 @@ def _run_ls(args):
     project_number = args.projectnumber
     project_path = _project_collection_path(project_number)
     _info(f"Listing HPC-DME collection: {project_path}")
-    _info(
-        "Note: the DME search index may lag up to 60 minutes behind recent deposits."
-    )
+    _info("Note: the DME search index may lag up to 60 minutes behind recent deposits.")
 
     _step(1, f"verifying project collection exists: {project_path}")
     if not _collection_exists(project_path):
-        return _error(
-            f"Project collection does not exist in HPC-DME: {project_path}"
-        )
+        return _error(f"Project collection does not exist in HPC-DME: {project_path}")
     _ok("Project collection found.")
 
     _step(2, "querying data objects ...")

--- a/src/parkit/projark.py
+++ b/src/parkit/projark.py
@@ -60,6 +60,21 @@ def _duration_hms(start_time, end_time):
     return f"{hours:02d}:{minutes:02d}:{seconds:02d}"
 
 
+def _print_hpcdme_properties():
+    hpc_dm_utils = os.environ.get("HPC_DM_UTILS", "")
+    props_path = Path(hpc_dm_utils) / "hpcdme.properties"
+    _info(f"HPC-DME configuration ({props_path}):")
+    try:
+        with open(props_path) as fh:
+            for line in fh:
+                stripped = line.rstrip("\n")
+                if stripped.startswith("#") or stripped.strip() == "":
+                    continue
+                print(f"    {stripped}")
+    except OSError as e:
+        _info(f"Could not read {props_path}: {e}")
+
+
 def _resolved_path_for_report(raw_path):
     if not raw_path:
         return ""
@@ -422,6 +437,7 @@ def _run_deposit(args):
     )
     _require_terminal_multiplexer()
     _ok("Session check passed (inside tmux/screen/Open OnDemand graphical session).")
+    _print_hpcdme_properties()
 
     source_folder = _resolve_existing_directory(args.folder)
     project_tag = _project_tag(args.projectnumber)

--- a/src/parkit/projark.py
+++ b/src/parkit/projark.py
@@ -333,45 +333,24 @@ def _insert_counter(name, n):
     return f"{name[:dot]}_{n:03d}{name[dot:]}"
 
 
-def _resolve_name_conflicts(datatype_dir, datatype_collection):
-    """Rename all staged files when any would collide with an existing HPC-DME object.
-
-    Checks each non-dot, non-.md5 file against the destination collection. If any
-    conflict is found, locates the lowest counter N (001, 002, ...) for which none
-    of the candidate names exist in HPC-DME, then renames every file in the
-    staging directory (primary and .md5 alike) using _insert_counter.
+def _resolve_tarname(tarname, datatype_collection):
+    """Return tarname unchanged if no conflict exists in HPC-DME, otherwise return
+    the name with the lowest free _NNN counter inserted before the first extension.
     """
-    all_files = sorted(
-        p for p in datatype_dir.iterdir() if not p.name.startswith(".")
-    )
-    non_md5 = [p for p in all_files if not p.name.endswith(".md5")]
-
-    conflicts = [p for p in non_md5 if _dataobject_exists(f"{datatype_collection}/{p.name}")]
-    if not conflicts:
-        _info("No file name conflicts found in HPC-DME destination collection.")
-        return
-
-    _info(
-        f"{len(conflicts)} file(s) already exist in HPC-DME: "
-        + ", ".join(repr(p.name) for p in conflicts)
-    )
-
-    counter = None
+    if not _dataobject_exists(f"{datatype_collection}/{tarname}"):
+        _info(f"No name conflict found for {tarname!r} in HPC-DME.")
+        return tarname
     for n in range(1, 1000):
-        candidates = [_insert_counter(p.name, n) for p in non_md5]
-        if not any(_dataobject_exists(f"{datatype_collection}/{c}") for c in candidates):
-            counter = n
-            break
-    if counter is None:
-        raise RuntimeError(
-            f"Could not find a free counter for staged files in {datatype_collection} after 999 attempts."
-        )
-
-    _info(f"Renaming all staged files with counter _{counter:03d} to avoid collisions.")
-    for fpath in all_files:
-        new_name = _insert_counter(fpath.name, counter)
-        _info(f"  {fpath.name!r} -> {new_name!r}")
-        fpath.rename(fpath.parent / new_name)
+        candidate = _insert_counter(tarname, n)
+        if not _dataobject_exists(f"{datatype_collection}/{candidate}"):
+            _info(
+                f"Name conflict: {tarname!r} already exists in HPC-DME. "
+                f"Using {candidate!r} instead."
+            )
+            return candidate
+    raise RuntimeError(
+        f"Could not find a free name for {tarname!r} in {datatype_collection} after 999 attempts."
+    )
 
 
 def _register_collection(collection_path, collection_type, extra_metadata=None):
@@ -540,6 +519,8 @@ def _run_deposit(args):
     tarname = args.tarname if args.tarname else _default_tarname(args.projectnumber)
     if "/" in tarname:
         return _error("--tarname must be a file name, not a path.")
+    _info("Checking for tar file name conflict in HPC-DME destination collection ...")
+    tarname = _resolve_tarname(tarname, datatype_collection)
     tar_path = datatype_dir / tarname
 
     _step(5, f"creating tarball from folder: {source_folder}")
@@ -550,9 +531,6 @@ def _run_deposit(args):
 
     _split_if_needed(tar_path, args.split_size_gb)
     _write_md5_files(datatype_dir)
-
-    _info("Checking for file name conflicts with existing HPC-DME collection objects ...")
-    _resolve_name_conflicts(datatype_dir, datatype_collection)
 
     _step(6, "transferring staged directory to HPC-DME ...")
     src_dir = f"{datatype_dir}/"

--- a/src/parkit/projark.py
+++ b/src/parkit/projark.py
@@ -1039,14 +1039,15 @@ def main():
 
     end_time = datetime.now().astimezone()
     status = "SUCCESS" if return_code == 0 else "FAILED"
-    _send_notification_email(
-        args=args,
-        status=status,
-        return_code=return_code,
-        start_time=start_time,
-        end_time=end_time,
-        error_message=error_message,
-    )
+    if args.command != "ls":
+        _send_notification_email(
+            args=args,
+            status=status,
+            return_code=return_code,
+            start_time=start_time,
+            end_time=end_time,
+            error_message=error_message,
+        )
 
     sys.exit(return_code)
 

--- a/src/parkit/projark.py
+++ b/src/parkit/projark.py
@@ -657,30 +657,42 @@ def _run_retrieve(args):
     target_dir.mkdir(parents=True, exist_ok=True)
     _step(4, f"local download directory: {target_dir}")
 
+    # Fetch the full object listing once — used for existence checks and split
+    # detection, replacing N serial dm_get_dataobject calls with a single query.
+    _step(5, "fetching object listing from HPC-DME ...")
+    all_objects = _query_all_dataobjects(datatype_collection)
+    known_names = {Path(p).name for p, _s, _d, _dt in all_objects}
+    _info(f"{len(known_names)} object(s) found in {datatype_collection}.")
+
+    # Detect split tar parts and warn/auto-set unsplit
+    split_names = {n for n in known_names if re.search(r"\.tar_\d{4}$", n)}
+    if split_names and not args.unspilt:
+        _info(
+            "Split tar parts detected in the collection "
+            f"({', '.join(sorted(split_names))}). "
+            "Pass --unsplit to automatically merge them after download."
+        )
+
     if args.filenames:
-        _step(5, "parsing requested filenames ...")
+        _step(6, "parsing requested filenames ...")
         filenames = _parse_filenames(args.filenames)
 
-        _step(6, "verifying all requested objects exist ...")
-        missing = []
+        _step(7, "verifying all requested objects exist ...")
+        missing = [f for f in filenames if f not in known_names]
         for filename in filenames:
-            object_path = f"{datatype_collection}/{filename}"
-            exists = _dataobject_exists(object_path)
-            _info(f"  - {filename}: {'FOUND' if exists else 'MISSING'}")
-            if not exists:
-                missing.append(filename)
+            _info(f"  - {filename}: {'FOUND' if filename in known_names else 'MISSING'}")
         if missing:
             return _error(f"Cannot proceed; missing object(s): {', '.join(missing)}")
 
-        _step(7, "downloading requested objects ...")
+        _step(8, "downloading requested objects ...")
         for filename in filenames:
             object_path = f"{datatype_collection}/{filename}"
             cmd = f"dm_download_dataobject {shlex.quote(object_path)} {shlex.quote(str(target_dir))}"
             run_dm_cmd(dm_cmd=cmd, errormsg=f"Failed to download {filename}")
             _ok(f"Downloaded: {filename}")
     else:
-        _step(5, "no --filenames provided; full collection mode selected.")
-        _step(6, "downloading full collection ...")
+        _step(6, "no --filenames provided; full collection mode selected.")
+        _step(7, "downloading full collection ...")
         # Download the datatype collection under base_local so we get:
         # <base_local>/<datatype>/...
         # and avoid nested paths like <base_local>/<datatype>/<datatype>/...
@@ -689,13 +701,13 @@ def _run_retrieve(args):
             dm_cmd=cmd, errormsg=f"Failed to download collection {datatype_collection}"
         )
         _ok(f"Downloaded full collection: {datatype_collection}")
-        _step(7, "per-file verification skipped in full collection mode.")
+        _step(8, "per-file verification skipped in full collection mode.")
 
     if args.unspilt:
-        _step(8, "--unspilt requested; checking for tar parts to merge ...")
+        _step(9, "--unspilt requested; checking for tar parts to merge ...")
         _merge_split_tar_parts(target_dir)
     else:
-        _step(8, "--unspilt not requested; skipping merge step.")
+        _step(9, "--unspilt not requested; skipping merge step.")
 
     _ok("Retrieve workflow finished successfully.")
     return 0

--- a/src/parkit/projark.py
+++ b/src/parkit/projark.py
@@ -694,10 +694,10 @@ def _run_retrieve(args):
         _step(8, "per-file verification skipped in full collection mode.")
 
     if args.unspilt:
-        _step(9, "--unspilt requested; checking for tar parts to merge ...")
+        _step(9, "--unsplit requested; checking for tar parts to merge ...")
         _merge_split_tar_parts(target_dir)
     else:
-        _step(9, "--unspilt not requested; skipping merge step.")
+        _step(9, "--unsplit not requested; skipping merge step.")
 
     _ok("Retrieve workflow finished successfully.")
     return 0

--- a/src/parkit/projark.py
+++ b/src/parkit/projark.py
@@ -336,13 +336,25 @@ def _insert_counter(name, n):
 def _resolve_tarname(tarname, datatype_collection):
     """Return tarname unchanged if no conflict exists in HPC-DME, otherwise return
     the name with the lowest free _NNN counter inserted before the first extension.
+
+    A conflict exists when either the base tarball (e.g. ccbr982.tar) **or** its
+    first split chunk (e.g. ccbr982.tar_0001) already exists in the collection.
+    The latter covers prior deposits whose tarball was large enough to be split,
+    in which case the base name never lands in HPC-DME as a data object.
     """
-    if not _dataobject_exists(f"{datatype_collection}/{tarname}"):
+
+    def _name_is_taken(name):
+        if _dataobject_exists(f"{datatype_collection}/{name}"):
+            return True
+        first_chunk = f"{name}_0001"
+        return _dataobject_exists(f"{datatype_collection}/{first_chunk}")
+
+    if not _name_is_taken(tarname):
         _info(f"No name conflict found for {tarname!r} in HPC-DME.")
         return tarname
     for n in range(1, 1000):
         candidate = _insert_counter(tarname, n)
-        if not _dataobject_exists(f"{datatype_collection}/{candidate}"):
+        if not _name_is_taken(candidate):
             _info(
                 f"Name conflict: {tarname!r} already exists in HPC-DME. "
                 f"Using {candidate!r} instead."

--- a/src/parkit/projark.py
+++ b/src/parkit/projark.py
@@ -718,9 +718,28 @@ _LS_CRITERIA = {
 }
 
 
+def _parse_deposit_date(raw_value):
+    """Parse data_transfer_completed (e.g. '06-25-2026 01:30:16') → 'YYMMDD'.
+    Returns None if the value cannot be parsed.
+    """
+    if not raw_value:
+        return None
+    for fmt in ("%m-%d-%Y %H:%M:%S", "%m-%d-%Y"):
+        try:
+            return datetime.strptime(str(raw_value).strip(), fmt).strftime("%y%m%d")
+        except ValueError:
+            pass
+    return None
+
+
 def _query_all_dataobjects(project_path):
-    """Return a list of (absolute_path, size_bytes) for every data object under
-    *project_path*, iterating through all pages."""
+    """Return a list of (absolute_path, size_bytes, depositor, deposit_date) for
+    every data object under *project_path*, iterating through all pages.
+
+    *depositor* is the display name of the registering user (registered_by_name)
+    falling back to their userid (registered_by), or None if unavailable.
+    *deposit_date* is data_transfer_completed formatted as YYMMDD, or None.
+    """
     objects = []
     page = 1
     while True:
@@ -758,15 +777,25 @@ def _query_all_dataobjects(project_path):
         for item in page_items:
             abs_path = (item.get("dataObject") or {}).get("absolutePath", "")
             size = None
+            depositor_name = None
+            depositor_id = None
+            deposit_date = None
             for entry in (item.get("metadataEntries") or {}).get("selfMetadataEntries", []):
-                if entry.get("attribute") == "source_file_size":
+                attr = entry.get("attribute")
+                if attr == "source_file_size":
                     try:
                         size = int(entry["value"])
                     except (ValueError, TypeError):
                         pass
-                    break
+                elif attr == "registered_by_name":
+                    depositor_name = str(entry["value"]).strip() or None
+                elif attr == "registered_by":
+                    depositor_id = str(entry["value"]).strip() or None
+                elif attr == "data_transfer_completed":
+                    deposit_date = _parse_deposit_date(entry["value"])
+            depositor = depositor_name or depositor_id
             if abs_path:
-                objects.append((abs_path, size))
+                objects.append((abs_path, size, depositor, deposit_date))
 
         total = data.get("totalCount", 0) or 0
         limit = data.get("limit", 100) or 100
@@ -780,15 +809,15 @@ def _query_all_dataobjects(project_path):
 def _render_ls_tree(project_path, objects):
     """Print a tree of *objects* grouped by their immediate parent sub-collection."""
     # Group objects by their direct parent path (sub-collection)
-    sub_collections: dict[str, list[tuple[str, int | None]]] = {}
-    for abs_path, size in objects:
+    sub_collections: dict[str, list[tuple[str, int | None, str | None, str | None]]] = {}
+    for abs_path, size, depositor, deposit_date in objects:
         parent = str(Path(abs_path).parent)
-        sub_collections.setdefault(parent, []).append((abs_path, size))
+        sub_collections.setdefault(parent, []).append((abs_path, size, depositor, deposit_date))
 
     # Compute sub-collection sizes (sum of known object sizes)
     def _sub_size(items):
         total = 0
-        for _, s in items:
+        for _, s, _d, _dt in items:
             if s is None:
                 return None
             total += s
@@ -796,7 +825,7 @@ def _render_ls_tree(project_path, objects):
 
     # Project header — use the short name (last path component)
     project_name = Path(project_path).name
-    total_all = sum(s for _, s in objects if s is not None) if objects else 0
+    total_all = sum(s for _, s, _d, _dt in objects if s is not None) if objects else 0
     print(f"{project_name}  ({_human_size(total_all)})")
 
     sorted_subs = sorted(sub_collections.keys())
@@ -810,12 +839,13 @@ def _render_ls_tree(project_path, objects):
 
         child_prefix = "    " if is_last_sub else "│   "
         items = sorted(sub_collections[sub_path], key=lambda x: Path(x[0]).name)
-        for item_idx, (abs_path, size) in enumerate(items):
+        for item_idx, (abs_path, size, depositor, deposit_date) in enumerate(items):
             is_last_item = item_idx == len(items) - 1
             item_connector = "└──" if is_last_item else "├──"
             fname = Path(abs_path).name
             sz_str = _human_size(size) if size is not None else "unknown"
-            print(f"{child_prefix}{item_connector} {fname:<50}  {sz_str}")
+            dep_col = ",".join(filter(None, [depositor, deposit_date])) or ""
+            print(f"{child_prefix}{item_connector} {fname:<50}  {sz_str:<12}  {dep_col}")
 
 
 def _run_ls(args):

--- a/src/parkit/projark.py
+++ b/src/parkit/projark.py
@@ -14,7 +14,8 @@ from tempfile import NamedTemporaryFile
 from parkit.src.VersionCheck import __version__
 from parkit.src.checkapisync import check_hpc_dme_apis_sync
 from parkit.src.createtar import createtar
-from parkit.src.utils import get_md5sum, run_dm_cmd
+from parkit.src.lscollection import ls_collection, query_all_dataobjects
+from parkit.src.utils import collection_exists, get_md5sum, human_size, run_dm_cmd
 
 
 DEFAULT_SPLIT_SIZE_GB = 500.0
@@ -22,13 +23,8 @@ NOTIFY_FROM_EMAIL = "NCICCBR@mail.nih.gov"
 
 
 def _human_size(num_bytes):
-    units = ["B", "KB", "MB", "GB", "TB", "PB"]
-    value = float(num_bytes)
-    unit_index = 0
-    while value >= 1024 and unit_index < len(units) - 1:
-        value /= 1024.0
-        unit_index += 1
-    return f"{value:.2f} {units[unit_index]}"
+    """Thin alias kept for internal use; delegates to the shared utility."""
+    return human_size(num_bytes)
 
 
 def _info(message):
@@ -298,14 +294,8 @@ def _require_terminal_multiplexer():
 
 
 def _collection_exists(collection_path):
-    cmd = f"dm_get_collection {shlex.quote(collection_path)}"
-    proc = run_dm_cmd(
-        dm_cmd=cmd,
-        errormsg=f"Failed while checking collection {collection_path}",
-        returnproc=True,
-        exitiffails=False,
-    )
-    return proc.returncode == 0
+    """Thin alias kept for internal use; delegates to the shared utility."""
+    return collection_exists(collection_path)
 
 
 def _dataobject_exists(object_path):
@@ -660,7 +650,7 @@ def _run_retrieve(args):
     # Fetch the full object listing once — used for existence checks and split
     # detection, replacing N serial dm_get_dataobject calls with a single query.
     _step(5, "fetching object listing from HPC-DME ...")
-    all_objects = _query_all_dataobjects(datatype_collection)
+    all_objects = query_all_dataobjects(datatype_collection)
     known_names = {Path(p).name for p, _s, _d, _dt in all_objects}
     _info(f"{len(known_names)} object(s) found in {datatype_collection}.")
 
@@ -713,158 +703,10 @@ def _run_retrieve(args):
     return 0
 
 
-_LS_CRITERIA = {
-    "compoundQuery": {
-        "operator": "AND",
-        "queries": [
-            {
-                "attribute": "source_file_size",
-                "value": "0",
-                "operator": "NUM_GREATER_OR_EQUAL",
-            }
-        ],
-    },
-    "detailedResponse": True,
-    "page": 1,
-    "totalCount": True,
-}
-
-
-def _parse_deposit_date(raw_value):
-    """Parse data_transfer_completed (e.g. '06-25-2026 01:30:16') → 'YYMMDD'.
-    Returns None if the value cannot be parsed.
-    """
-    if not raw_value:
-        return None
-    for fmt in ("%m-%d-%Y %H:%M:%S", "%m-%d-%Y"):
-        try:
-            return datetime.strptime(str(raw_value).strip(), fmt).strftime("%y%m%d")
-        except ValueError:
-            pass
-    return None
-
-
-def _query_all_dataobjects(project_path):
-    """Return a list of (absolute_path, size_bytes, depositor, deposit_date) for
-    every data object under *project_path*, iterating through all pages.
-
-    *depositor* is the display name of the registering user (registered_by_name)
-    falling back to their userid (registered_by), or None if unavailable.
-    *deposit_date* is data_transfer_completed formatted as YYMMDD, or None.
-    """
-    objects = []
-    page = 1
-    while True:
-        criteria = dict(_LS_CRITERIA)
-        criteria["page"] = page
-        with NamedTemporaryFile("w", suffix=".json", delete=False) as tmp:
-            json.dump(criteria, tmp, indent=2)
-            criteria_file = tmp.name
-        try:
-            cmd = (
-                f"dm_query_dataobject -o /dev/stdout"
-                f" {shlex.quote(criteria_file)} {shlex.quote(project_path)}"
-            )
-            proc = run_dm_cmd(
-                dm_cmd=cmd,
-                errormsg="dm_query_dataobject failed during ls",
-                returnproc=True,
-                exitiffails=False,
-            )
-        finally:
-            if os.path.exists(criteria_file):
-                os.remove(criteria_file)
-
-        if proc.returncode != 0:
-            _info("dm_query_dataobject returned non-zero; no objects found or query failed.")
-            break
-
-        try:
-            data = json.loads(proc.stdout)
-        except (json.JSONDecodeError, AttributeError):
-            _info("Could not parse dm_query_dataobject output as JSON.")
-            break
-
-        page_items = data.get("dataObjects", []) or []
-        for item in page_items:
-            abs_path = (item.get("dataObject") or {}).get("absolutePath", "")
-            size = None
-            depositor_name = None
-            depositor_id = None
-            deposit_date = None
-            for entry in (item.get("metadataEntries") or {}).get("selfMetadataEntries", []):
-                attr = entry.get("attribute")
-                if attr == "source_file_size":
-                    try:
-                        size = int(entry["value"])
-                    except (ValueError, TypeError):
-                        pass
-                elif attr == "registered_by_name":
-                    depositor_name = str(entry["value"]).strip() or None
-                elif attr == "registered_by":
-                    depositor_id = str(entry["value"]).strip() or None
-                elif attr == "data_transfer_completed":
-                    deposit_date = _parse_deposit_date(entry["value"])
-            depositor = depositor_name or depositor_id
-            if abs_path:
-                objects.append((abs_path, size, depositor, deposit_date))
-
-        total = data.get("totalCount", 0) or 0
-        limit = data.get("limit", 100) or 100
-        if page * limit >= total:
-            break
-        page += 1
-
-    return objects
-
-
-def _render_ls_tree(project_path, objects):
-    """Print a tree of *objects* grouped by their immediate parent sub-collection."""
-    # Group objects by their direct parent path (sub-collection)
-    sub_collections: dict[str, list[tuple[str, int | None, str | None, str | None]]] = {}
-    for abs_path, size, depositor, deposit_date in objects:
-        parent = str(Path(abs_path).parent)
-        sub_collections.setdefault(parent, []).append((abs_path, size, depositor, deposit_date))
-
-    # Compute sub-collection sizes (sum of known object sizes)
-    def _sub_size(items):
-        total = 0
-        for _, s, _d, _dt in items:
-            if s is None:
-                return None
-            total += s
-        return total
-
-    # Project header — use the short name (last path component)
-    project_name = Path(project_path).name
-    total_all = sum(s for _, s, _d, _dt in objects if s is not None) if objects else 0
-    print(f"{project_name}  ({_human_size(total_all)})")
-
-    sorted_subs = sorted(sub_collections.keys())
-    for sub_idx, sub_path in enumerate(sorted_subs):
-        is_last_sub = sub_idx == len(sorted_subs) - 1
-        sub_connector = "└──" if is_last_sub else "├──"
-        sub_name = Path(sub_path).name
-        sub_sz = _sub_size(sub_collections[sub_path])
-        sub_sz_str = f"  ({_human_size(sub_sz)})" if sub_sz is not None else ""
-        print(f"{sub_connector} {sub_name}/{sub_sz_str}")
-
-        child_prefix = "    " if is_last_sub else "│   "
-        items = sorted(sub_collections[sub_path], key=lambda x: Path(x[0]).name)
-        for item_idx, (abs_path, size, depositor, deposit_date) in enumerate(items):
-            is_last_item = item_idx == len(items) - 1
-            item_connector = "└──" if is_last_item else "├──"
-            fname = Path(abs_path).name
-            sz_str = _human_size(size) if size is not None else "unknown"
-            dep_col = ",".join(filter(None, [depositor, deposit_date])) or ""
-            print(f"{child_prefix}{item_connector} {fname:<50}  {sz_str:<12}  {dep_col}")
-
-
 def _run_ls(args):
     _print_hpcdme_properties()
 
-    project_number = args.projectnumber
-    project_path = _project_collection_path(project_number)
+    project_path = _project_collection_path(args.projectnumber)
     _info(f"Listing HPC-DME collection: {project_path}")
     _info(
         "Note: the DME search index may lag up to 60 minutes behind recent deposits."
@@ -878,17 +720,7 @@ def _run_ls(args):
     _ok("Project collection found.")
 
     _step(2, "querying data objects ...")
-    objects = _query_all_dataobjects(project_path)
-    _ok(f"{len(objects)} object(s) found.")
-
-    if not objects:
-        _info("No data objects found under this project collection.")
-        return 0
-
-    print()
-    _render_ls_tree(project_path, objects)
-    print()
-    return 0
+    return ls_collection(project_path, json_output=args.json)
 
 
 def _build_parser():
@@ -1019,6 +851,12 @@ def _build_parser():
         metavar="PROJECTNUMBER",
         type=_normalize_project_number,
         help="Project number (e.g. 982, ccbr982, CCBR-982)",
+    )
+    parser_ls.add_argument(
+        "--json",
+        action="store_true",
+        default=False,
+        help="Emit results as a JSON array instead of the tree view",
     )
 
     return parser

--- a/src/parkit/projark.py
+++ b/src/parkit/projark.py
@@ -273,15 +273,17 @@ def _dataobject_exists(object_path):
     return proc.returncode == 0
 
 
-def _register_collection(collection_path, collection_type):
-    # Minimal metadata payload used to create a collection if it does not exist.
+def _register_collection(collection_path, collection_type, extra_metadata=None):
     payload = {
         "metadataEntries": [{"attribute": "collection_type", "value": collection_type}]
     }
+    if extra_metadata:
+        payload["metadataEntries"].extend(extra_metadata)
     with NamedTemporaryFile("w", suffix=".json", delete=False) as tmp:
         json.dump(payload, tmp, indent=2)
         temp_json = tmp.name
 
+    _info(f"Collection registration payload:\n{json.dumps(payload, indent=2)}")
     try:
         cmd = f"dm_register_collection {shlex.quote(temp_json)} {shlex.quote(collection_path)}"
         run_dm_cmd(
@@ -292,7 +294,7 @@ def _register_collection(collection_path, collection_type):
             os.remove(temp_json)
 
 
-def _ensure_deposit_collections(base_collection, datatype):
+def _ensure_deposit_collections(base_collection, datatype, project_number):
     datatype_collection = f"{base_collection}/{datatype}"
     _info(f"Step 3: verifying destination collection: {datatype_collection}")
     if _collection_exists(datatype_collection):
@@ -303,12 +305,33 @@ def _ensure_deposit_collections(base_collection, datatype):
     if not _collection_exists(base_collection):
         _info(f"Project collection missing: {base_collection}")
         _info("Creating project collection first ...")
-        _register_collection(base_collection, "Project")
+        project_label = f"CCBR-{project_number}"
+        today = datetime.now().strftime("%Y%m%d")
+        project_metadata = [
+            {"attribute": "project_title", "value": project_label},
+            {"attribute": "project_description", "value": project_label},
+            {"attribute": "origin", "value": "CCBR"},
+            {"attribute": "method", "value": "NGS"},
+            {"attribute": "access", "value": "Open Access"},
+            {"attribute": "organism", "value": "unknown"},
+            {"attribute": "summary_of_samples", "value": "unknown"},
+            {"attribute": "project_start_date", "value": today, "dateFormat": "yyyyMMdd"},
+        ]
+        _register_collection(base_collection, "Project", extra_metadata=project_metadata)
     else:
         _info("Project collection exists.")
 
     _info(f"Creating datatype collection: {datatype_collection}")
-    _register_collection(datatype_collection, datatype)
+    # DME valid collection_type values: [Project, PI_Lab, Sample, Analysis].
+    # "Rawdata" is not a valid type, so map it to "Analysis".
+    datatype_collection_type = "Analysis" if datatype == "Rawdata" else datatype
+    today = datetime.now().strftime("%Y%m%d")
+    datatype_metadata = [
+        {"attribute": "project_start_date", "value": today, "dateFormat": "yyyyMMdd"},
+        {"attribute": "method", "value": "NGS"},
+        {"attribute": "number_of_cases", "value": "unknown"},
+    ]
+    _register_collection(datatype_collection, datatype_collection_type, extra_metadata=datatype_metadata)
     return datatype_collection
 
 
@@ -396,7 +419,7 @@ def _run_deposit(args):
     project_tag = _project_tag(args.projectnumber)
     base_collection = _project_collection_path(args.projectnumber)
     datatype = args.datatype
-    datatype_collection = _ensure_deposit_collections(base_collection, datatype)
+    datatype_collection = _ensure_deposit_collections(base_collection, datatype, args.projectnumber)
 
     scratch_root, datatype_dir = _prepare_scratch_dirs(project_tag, datatype)
 

--- a/src/parkit/projark.py
+++ b/src/parkit/projark.py
@@ -319,6 +319,61 @@ def _dataobject_exists(object_path):
     return proc.returncode == 0
 
 
+def _insert_counter(name, n):
+    """Insert _{n:03d} before the first '.' in name, or append if no '.' exists.
+
+    Examples:
+        ccbr1431.tar           -> ccbr1431_001.tar
+        ccbr1431.tar.filelist  -> ccbr1431_001.tar.filelist
+        ccbr1431.tar_0001      -> ccbr1431_001.tar_0001
+    """
+    dot = name.find(".")
+    if dot == -1:
+        return f"{name}_{n:03d}"
+    return f"{name[:dot]}_{n:03d}{name[dot:]}"
+
+
+def _resolve_name_conflicts(datatype_dir, datatype_collection):
+    """Rename all staged files when any would collide with an existing HPC-DME object.
+
+    Checks each non-dot, non-.md5 file against the destination collection. If any
+    conflict is found, locates the lowest counter N (001, 002, ...) for which none
+    of the candidate names exist in HPC-DME, then renames every file in the
+    staging directory (primary and .md5 alike) using _insert_counter.
+    """
+    all_files = sorted(
+        p for p in datatype_dir.iterdir() if not p.name.startswith(".")
+    )
+    non_md5 = [p for p in all_files if not p.name.endswith(".md5")]
+
+    conflicts = [p for p in non_md5 if _dataobject_exists(f"{datatype_collection}/{p.name}")]
+    if not conflicts:
+        _info("No file name conflicts found in HPC-DME destination collection.")
+        return
+
+    _info(
+        f"{len(conflicts)} file(s) already exist in HPC-DME: "
+        + ", ".join(repr(p.name) for p in conflicts)
+    )
+
+    counter = None
+    for n in range(1, 1000):
+        candidates = [_insert_counter(p.name, n) for p in non_md5]
+        if not any(_dataobject_exists(f"{datatype_collection}/{c}") for c in candidates):
+            counter = n
+            break
+    if counter is None:
+        raise RuntimeError(
+            f"Could not find a free counter for staged files in {datatype_collection} after 999 attempts."
+        )
+
+    _info(f"Renaming all staged files with counter _{counter:03d} to avoid collisions.")
+    for fpath in all_files:
+        new_name = _insert_counter(fpath.name, counter)
+        _info(f"  {fpath.name!r} -> {new_name!r}")
+        fpath.rename(fpath.parent / new_name)
+
+
 def _register_collection(collection_path, collection_type, extra_metadata=None):
     payload = {
         "metadataEntries": [{"attribute": "collection_type", "value": collection_type}]
@@ -495,6 +550,9 @@ def _run_deposit(args):
 
     _split_if_needed(tar_path, args.split_size_gb)
     _write_md5_files(datatype_dir)
+
+    _info("Checking for file name conflicts with existing HPC-DME collection objects ...")
+    _resolve_name_conflicts(datatype_dir, datatype_collection)
 
     _step(6, "transferring staged directory to HPC-DME ...")
     src_dir = f"{datatype_dir}/"

--- a/src/parkit/src/lscollection.py
+++ b/src/parkit/src/lscollection.py
@@ -86,7 +86,9 @@ def query_all_dataobjects(collection_path):
                 os.remove(criteria_file)
 
         if proc.returncode != 0:
-            print("dm_query_dataobject returned non-zero; no objects found or query failed.")
+            print(
+                "dm_query_dataobject returned non-zero; no objects found or query failed."
+            )
             break
 
         try:
@@ -102,7 +104,9 @@ def query_all_dataobjects(collection_path):
             depositor_name = None
             depositor_id = None
             deposit_date = None
-            for entry in (item.get("metadataEntries") or {}).get("selfMetadataEntries", []):
+            for entry in (item.get("metadataEntries") or {}).get(
+                "selfMetadataEntries", []
+            ):
                 attr = entry.get("attribute")
                 if attr == "source_file_size":
                     try:
@@ -140,7 +144,7 @@ def _build_tree(collection_path, objects):
     for abs_path, size, depositor, deposit_date in objects:
         if not abs_path.startswith(prefix):
             continue
-        rel = abs_path[len(prefix):]
+        rel = abs_path[len(prefix) :]
         parts = rel.split("/")
         node = root
         for part in parts[:-1]:
@@ -180,12 +184,12 @@ def _render_node(node, prefix, is_last, label, indent):
     total_children = len(subdirs) + len(files)
 
     for idx, subdir in enumerate(subdirs):
-        is_last_child = (idx == total_children - 1)
+        is_last_child = idx == total_children - 1
         _render_node(node[subdir], prefix, is_last_child, subdir, child_indent)
 
     for idx, (fname, _path, size, depositor, deposit_date) in enumerate(files):
         item_idx = len(subdirs) + idx
-        is_last_item = (item_idx == total_children - 1)
+        is_last_item = item_idx == total_children - 1
         item_connector = "└──" if is_last_item else "├──"
         sz_str = human_size(size) if size is not None else "unknown"
         dep_col = ",".join(filter(None, [depositor, deposit_date])) or ""
@@ -205,12 +209,12 @@ def render_ls_tree(collection_path, objects):
     total_top = len(subdirs) + len(files)
 
     for idx, subdir in enumerate(subdirs):
-        is_last = (idx == total_top - 1)
+        is_last = idx == total_top - 1
         _render_node(root[subdir], collection_path, is_last, subdir, "")
 
     for idx, (fname, _path, size, depositor, deposit_date) in enumerate(files):
         item_idx = len(subdirs) + idx
-        is_last = (item_idx == total_top - 1)
+        is_last = item_idx == total_top - 1
         connector = "└──" if is_last else "├──"
         sz_str = human_size(size) if size is not None else "unknown"
         dep_col = ",".join(filter(None, [depositor, deposit_date])) or ""
@@ -221,13 +225,15 @@ def render_ls_json(objects):
     """Print *objects* as a JSON array to stdout."""
     records = []
     for abs_path, size, depositor, deposit_date in objects:
-        records.append({
-            "path": abs_path,
-            "size_bytes": size,
-            "size_human": human_size(size) if size is not None else None,
-            "depositor": depositor,
-            "deposit_date": deposit_date,
-        })
+        records.append(
+            {
+                "path": abs_path,
+                "size_bytes": size,
+                "size_human": human_size(size) if size is not None else None,
+                "depositor": depositor,
+                "deposit_date": deposit_date,
+            }
+        )
     print(json.dumps(records, indent=2))
 
 

--- a/src/parkit/src/lscollection.py
+++ b/src/parkit/src/lscollection.py
@@ -128,43 +128,93 @@ def query_all_dataobjects(collection_path):
     return objects
 
 
-def render_ls_tree(collection_path, objects):
-    """Print *objects* as a box-drawing tree grouped by immediate parent path."""
-    sub_collections: dict[str, list[tuple[str, int | None, str | None, str | None]]] = {}
+def _build_tree(collection_path, objects):
+    """Build a nested dict tree from *objects* relative to *collection_path*.
+
+    Each node is a dict with:
+      '__files__': list of (name, abs_path, size, depositor, deposit_date)
+      '<subdir>':  child node (same structure)
+    """
+    root = {"__files__": []}
+    prefix = collection_path.rstrip("/") + "/"
     for abs_path, size, depositor, deposit_date in objects:
-        parent = str(Path(abs_path).parent)
-        sub_collections.setdefault(parent, []).append((abs_path, size, depositor, deposit_date))
+        if not abs_path.startswith(prefix):
+            continue
+        rel = abs_path[len(prefix):]
+        parts = rel.split("/")
+        node = root
+        for part in parts[:-1]:
+            node = node.setdefault(part, {"__files__": []})
+        node["__files__"].append((parts[-1], abs_path, size, depositor, deposit_date))
+    return root
 
-    def _sub_size(items):
-        total = 0
-        for _, s, _d, _dt in items:
-            if s is None:
-                return None
-            total += s
-        return total
 
+def _node_size(node):
+    """Recursively sum source_file_size for all files under *node*. Returns None if any unknown."""
+    total = 0
+    for _name, _path, s, _d, _dt in node.get("__files__", []):
+        if s is None:
+            return None
+        total += s
+    for key, child in node.items():
+        if key == "__files__":
+            continue
+        cs = _node_size(child)
+        if cs is None:
+            return None
+        total += cs
+    return total
+
+
+def _render_node(node, prefix, is_last, label, indent):
+    """Recursively render a tree node."""
+    connector = "└──" if is_last else "├──"
+    sz = _node_size(node)
+    sz_str = f"  ({human_size(sz)})" if sz is not None else ""
+    # directory node
+    print(f"{indent}{connector} {label}/{sz_str}")
+    child_indent = indent + ("    " if is_last else "│   ")
+
+    subdirs = sorted(k for k in node if k != "__files__")
+    files = sorted(node.get("__files__", []), key=lambda x: x[0])
+    total_children = len(subdirs) + len(files)
+
+    for idx, subdir in enumerate(subdirs):
+        is_last_child = (idx == total_children - 1)
+        _render_node(node[subdir], prefix, is_last_child, subdir, child_indent)
+
+    for idx, (fname, _path, size, depositor, deposit_date) in enumerate(files):
+        item_idx = len(subdirs) + idx
+        is_last_item = (item_idx == total_children - 1)
+        item_connector = "└──" if is_last_item else "├──"
+        sz_str = human_size(size) if size is not None else "unknown"
+        dep_col = ",".join(filter(None, [depositor, deposit_date])) or ""
+        print(f"{child_indent}{item_connector} {fname:<50}  {sz_str:<12}  {dep_col}")
+
+
+def render_ls_tree(collection_path, objects):
+    """Print *objects* as a recursive box-drawing tree rooted at *collection_path*."""
+    root = _build_tree(collection_path, objects)
     collection_name = Path(collection_path).name
-    total_all = sum(s for _, s, _d, _dt in objects if s is not None) if objects else 0
-    print(f"{collection_name}  ({human_size(total_all)})")
+    total_all = _node_size(root)
+    total_str = f"  ({human_size(total_all)})" if total_all is not None else ""
+    print(f"{collection_name}{total_str}")
 
-    sorted_subs = sorted(sub_collections.keys())
-    for sub_idx, sub_path in enumerate(sorted_subs):
-        is_last_sub = sub_idx == len(sorted_subs) - 1
-        sub_connector = "└──" if is_last_sub else "├──"
-        sub_name = Path(sub_path).name
-        sub_sz = _sub_size(sub_collections[sub_path])
-        sub_sz_str = f"  ({human_size(sub_sz)})" if sub_sz is not None else ""
-        print(f"{sub_connector} {sub_name}/{sub_sz_str}")
+    subdirs = sorted(k for k in root if k != "__files__")
+    files = sorted(root.get("__files__", []), key=lambda x: x[0])
+    total_top = len(subdirs) + len(files)
 
-        child_prefix = "    " if is_last_sub else "│   "
-        items = sorted(sub_collections[sub_path], key=lambda x: Path(x[0]).name)
-        for item_idx, (abs_path, size, depositor, deposit_date) in enumerate(items):
-            is_last_item = item_idx == len(items) - 1
-            item_connector = "└──" if is_last_item else "├──"
-            fname = Path(abs_path).name
-            sz_str = human_size(size) if size is not None else "unknown"
-            dep_col = ",".join(filter(None, [depositor, deposit_date])) or ""
-            print(f"{child_prefix}{item_connector} {fname:<50}  {sz_str:<12}  {dep_col}")
+    for idx, subdir in enumerate(subdirs):
+        is_last = (idx == total_top - 1)
+        _render_node(root[subdir], collection_path, is_last, subdir, "")
+
+    for idx, (fname, _path, size, depositor, deposit_date) in enumerate(files):
+        item_idx = len(subdirs) + idx
+        is_last = (item_idx == total_top - 1)
+        connector = "└──" if is_last else "├──"
+        sz_str = human_size(size) if size is not None else "unknown"
+        dep_col = ",".join(filter(None, [depositor, deposit_date])) or ""
+        print(f"{connector} {fname:<50}  {sz_str:<12}  {dep_col}")
 
 
 def render_ls_json(objects):

--- a/src/parkit/src/lscollection.py
+++ b/src/parkit/src/lscollection.py
@@ -1,0 +1,210 @@
+"""lscollection — list HPC-DME collection contents as a tree or JSON.
+
+Public API
+----------
+ls_collection(collection_path, json_output=False) -> int
+    Query all data objects under *collection_path* and render them as a
+    tree (default) or as a JSON array (when *json_output* is True).
+    Returns 0 on success.
+
+The functions in this module are also used by ``projark ls`` so that
+both ``parkit ls`` and ``projark ls`` share a single implementation.
+"""
+
+import json
+import os
+import shlex
+from datetime import datetime
+from pathlib import Path
+from tempfile import NamedTemporaryFile
+
+from parkit.src.utils import human_size, run_dm_cmd
+
+
+_LS_CRITERIA = {
+    "compoundQuery": {
+        "operator": "AND",
+        "queries": [
+            {
+                "attribute": "source_file_size",
+                "value": "0",
+                "operator": "NUM_GREATER_OR_EQUAL",
+            }
+        ],
+    },
+    "detailedResponse": True,
+    "page": 1,
+    "totalCount": True,
+}
+
+
+def parse_deposit_date(raw_value):
+    """Parse a DME ``data_transfer_completed`` value to ``YYMMDD`` string.
+
+    Accepts ``'MM-DD-YYYY HH:MM:SS'`` or ``'MM-DD-YYYY'``.
+    Returns ``None`` if the value is absent or cannot be parsed.
+    """
+    if not raw_value:
+        return None
+    for fmt in ("%m-%d-%Y %H:%M:%S", "%m-%d-%Y"):
+        try:
+            return datetime.strptime(str(raw_value).strip(), fmt).strftime("%y%m%d")
+        except ValueError:
+            pass
+    return None
+
+
+def query_all_dataobjects(collection_path):
+    """Return a list of ``(absolute_path, size_bytes, depositor, deposit_date)``
+    for every data object under *collection_path*, iterating all pages.
+
+    *depositor* is ``registered_by_name`` falling back to ``registered_by``,
+    or ``None`` if unavailable.
+    *deposit_date* is ``data_transfer_completed`` formatted as ``YYMMDD``, or ``None``.
+    """
+    objects = []
+    page = 1
+    while True:
+        criteria = dict(_LS_CRITERIA)
+        criteria["page"] = page
+        with NamedTemporaryFile("w", suffix=".json", delete=False) as tmp:
+            json.dump(criteria, tmp, indent=2)
+            criteria_file = tmp.name
+        try:
+            cmd = (
+                f"dm_query_dataobject -o /dev/stdout"
+                f" {shlex.quote(criteria_file)} {shlex.quote(collection_path)}"
+            )
+            proc = run_dm_cmd(
+                dm_cmd=cmd,
+                errormsg="dm_query_dataobject failed during ls",
+                returnproc=True,
+                exitiffails=False,
+            )
+        finally:
+            if os.path.exists(criteria_file):
+                os.remove(criteria_file)
+
+        if proc.returncode != 0:
+            print("dm_query_dataobject returned non-zero; no objects found or query failed.")
+            break
+
+        try:
+            data = json.loads(proc.stdout)
+        except (json.JSONDecodeError, AttributeError):
+            print("Could not parse dm_query_dataobject output as JSON.")
+            break
+
+        page_items = data.get("dataObjects", []) or []
+        for item in page_items:
+            abs_path = (item.get("dataObject") or {}).get("absolutePath", "")
+            size = None
+            depositor_name = None
+            depositor_id = None
+            deposit_date = None
+            for entry in (item.get("metadataEntries") or {}).get("selfMetadataEntries", []):
+                attr = entry.get("attribute")
+                if attr == "source_file_size":
+                    try:
+                        size = int(entry["value"])
+                    except (ValueError, TypeError):
+                        pass
+                elif attr == "registered_by_name":
+                    depositor_name = str(entry["value"]).strip() or None
+                elif attr == "registered_by":
+                    depositor_id = str(entry["value"]).strip() or None
+                elif attr == "data_transfer_completed":
+                    deposit_date = parse_deposit_date(entry["value"])
+            depositor = depositor_name or depositor_id
+            if abs_path:
+                objects.append((abs_path, size, depositor, deposit_date))
+
+        total = data.get("totalCount", 0) or 0
+        limit = data.get("limit", 100) or 100
+        if page * limit >= total:
+            break
+        page += 1
+
+    return objects
+
+
+def render_ls_tree(collection_path, objects):
+    """Print *objects* as a box-drawing tree grouped by immediate parent path."""
+    sub_collections: dict[str, list[tuple[str, int | None, str | None, str | None]]] = {}
+    for abs_path, size, depositor, deposit_date in objects:
+        parent = str(Path(abs_path).parent)
+        sub_collections.setdefault(parent, []).append((abs_path, size, depositor, deposit_date))
+
+    def _sub_size(items):
+        total = 0
+        for _, s, _d, _dt in items:
+            if s is None:
+                return None
+            total += s
+        return total
+
+    collection_name = Path(collection_path).name
+    total_all = sum(s for _, s, _d, _dt in objects if s is not None) if objects else 0
+    print(f"{collection_name}  ({human_size(total_all)})")
+
+    sorted_subs = sorted(sub_collections.keys())
+    for sub_idx, sub_path in enumerate(sorted_subs):
+        is_last_sub = sub_idx == len(sorted_subs) - 1
+        sub_connector = "└──" if is_last_sub else "├──"
+        sub_name = Path(sub_path).name
+        sub_sz = _sub_size(sub_collections[sub_path])
+        sub_sz_str = f"  ({human_size(sub_sz)})" if sub_sz is not None else ""
+        print(f"{sub_connector} {sub_name}/{sub_sz_str}")
+
+        child_prefix = "    " if is_last_sub else "│   "
+        items = sorted(sub_collections[sub_path], key=lambda x: Path(x[0]).name)
+        for item_idx, (abs_path, size, depositor, deposit_date) in enumerate(items):
+            is_last_item = item_idx == len(items) - 1
+            item_connector = "└──" if is_last_item else "├──"
+            fname = Path(abs_path).name
+            sz_str = human_size(size) if size is not None else "unknown"
+            dep_col = ",".join(filter(None, [depositor, deposit_date])) or ""
+            print(f"{child_prefix}{item_connector} {fname:<50}  {sz_str:<12}  {dep_col}")
+
+
+def render_ls_json(objects):
+    """Print *objects* as a JSON array to stdout."""
+    records = []
+    for abs_path, size, depositor, deposit_date in objects:
+        records.append({
+            "path": abs_path,
+            "size_bytes": size,
+            "size_human": human_size(size) if size is not None else None,
+            "depositor": depositor,
+            "deposit_date": deposit_date,
+        })
+    print(json.dumps(records, indent=2))
+
+
+def ls_collection(collection_path, json_output=False):
+    """Query all data objects under *collection_path* and render output.
+
+    Parameters
+    ----------
+    collection_path:
+        Full HPC-DME absolute path (e.g. ``/CCBR_Archive/GRIDFTP/Project_CCBR-982``).
+    json_output:
+        When ``True``, emit a JSON array instead of the tree view.
+
+    Returns
+    -------
+    int
+        0 on success.
+    """
+    objects = query_all_dataobjects(collection_path)
+    if not objects:
+        print(f"No data objects found under {collection_path}.")
+        return 0
+
+    if json_output:
+        render_ls_json(objects)
+    else:
+        print()
+        render_ls_tree(collection_path, objects)
+        print()
+    return 0

--- a/src/parkit/src/utils.py
+++ b/src/parkit/src/utils.py
@@ -3,6 +3,7 @@ import sys
 import uuid
 import subprocess
 import hashlib
+import tempfile
 
 
 def has_write_permission(folder_path):
@@ -104,13 +105,16 @@ def run_dm_cmd(dm_cmd, errormsg="", returnproc=False, exitiffails=True):
     # cmd = f"export HPC_DM_UTILS=/data/kopardevn/SandBox/HPC_DME_APIs/utils && source $HPC_DM_UTILS/functions && {dm_cmd}"
     cmd = f"module load java/$HPC_DM_JAVA_VERSION && source $HPC_DM_UTILS/functions && {dm_cmd}"
     print(cmd)
-    proc = subprocess.run(
-        cmd,
-        capture_output=True,
-        shell=True,
-        text=True,
-        # env=env_vars
-    )
+    _user = os.environ.get("USER", "unknown")
+    with tempfile.TemporaryDirectory(prefix=f"parkit_{_user}_") as _dm_cwd:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            shell=True,
+            text=True,
+            cwd=_dm_cwd,
+            # env=env_vars
+        )
     exitcode = str(proc.returncode)
     if exitcode != "0":
         print("returncode:" + exitcode)

--- a/src/parkit/src/utils.py
+++ b/src/parkit/src/utils.py
@@ -139,3 +139,27 @@ def which(program):
         if os.path.exists(executable) and os.access(executable, os.X_OK):
             return executable
     return None
+
+
+def human_size(num_bytes):
+    """Return a human-readable string for *num_bytes* (e.g. '500.00 GB')."""
+    units = ["B", "KB", "MB", "GB", "TB", "PB"]
+    value = float(num_bytes)
+    unit_index = 0
+    while value >= 1024 and unit_index < len(units) - 1:
+        value /= 1024.0
+        unit_index += 1
+    return f"{value:.2f} {units[unit_index]}"
+
+
+def collection_exists(collection_path):
+    """Return True if *collection_path* exists as a collection in HPC-DME."""
+    import shlex
+    cmd = f"dm_get_collection {shlex.quote(collection_path)}"
+    proc = run_dm_cmd(
+        dm_cmd=cmd,
+        errormsg=f"Failed while checking collection {collection_path}",
+        returnproc=True,
+        exitiffails=False,
+    )
+    return proc.returncode == 0

--- a/src/parkit/src/utils.py
+++ b/src/parkit/src/utils.py
@@ -155,6 +155,7 @@ def human_size(num_bytes):
 def collection_exists(collection_path):
     """Return True if *collection_path* exists as a collection in HPC-DME."""
     import shlex
+
     cmd = f"dm_get_collection {shlex.quote(collection_path)}"
     proc = run_dm_cmd(
         dm_cmd=cmd,


### PR DESCRIPTION
## Changes

This PR contains all changes for the upcoming **v3.1.0** release. Full details are in [CHANGELOG.md](https://github.com/CCBR/parkit/blob/fix/projark-deposit-collections/CHANGELOG.md) under `## parkit development version`. Summary:

### New features

- **`projark ls <projectnumber>`** — list all data objects in a project's HPC-DME vault as a tree with human-readable sizes, depositor name, and deposit date. Accepts same project number formats as `deposit`/`retrieve`. No Helix/tmux/sync-gate checks required. No email notification sent. (#62)
- **`parkit ls <collection-path>`** — list any HPC-DME collection by full path. Backed by the same shared `lscollection.py` module as `projark ls`. Supports `--json` output for scripting. (#62)

### Bug fixes

- **`projark deposit` — HTTP 400 errors fixed**: `_register_collection` now sends all required HPC-DME metadata fields. Project collections include `project_title`, `project_description`, `origin`, `method`, `access`, `organism`, `summary_of_samples`, `project_start_date`. Analysis/Rawdata sub-collections include `project_start_date`, `method`, `number_of_cases`. `Rawdata` datatype now correctly maps to HPC-DME `collection_type` value `Analysis`. (#53)
- **Split-tar conflict detection**: `_resolve_tarname()` now also checks for the first split-chunk suffix (`*.tar_0001`) so a previously split deposit is correctly detected as a naming conflict. (#61)
- **Temp file isolation**: `run_dm_cmd()` now executes each `dm_*` call inside a `TemporaryDirectory`, preventing `*.tmp` response files from accumulating in the user's working directory and preventing concurrent-run collisions. (#60)

### Improvements

- **`projark deposit`** — after Step 2, prints active lines from `hpcdme.properties` so users can verify config before transfer. (#56)
- **`projark deposit`** — aborts with a descriptive error if proxy settings (`hpc.server.proxy.url`/`hpc.server.proxy.port`) are active in `hpcdme.properties`. (#57)
- **`projark deposit`** — dot/hidden files are excluded from `dm_register_directory` via a temp exclude file. (#58)
- **`projark deposit`** — pre-transfer conflict detection: checks the destination vault before uploading and renames staged files (inserting a zero-padded counter before the first extension) if a conflict is found. (#59)
- **`projark retrieve`** — replaced N serial `dm_get_dataobject` existence checks with a single `dm_query_dataobject` call. Also prints a split-tar advisory if `--unsplit` was not passed and split parts are detected. (#62)

## Issues

- Fixes #53, #56, #57, #58, #59, #60, #61, #62

## PR Checklist

- [x] This comment contains a description of changes with justifications, with any relevant issues linked.
- [ ] Write unit tests for any new features, bug fixes, or other code changes.
- [x] Update `CHANGELOG.md` with a short description of any user-facing changes and reference the PR number. Guidelines: https://keepachangelog.com/en/1.1.0/

_Generated using AI_